### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Treebie
 
 [![Build Status](https://travis-ci.org/twneale/treebie.svg?branch=master)](https://travis-ci.org/twneale/treebie)
 [![Coverage Status](https://coveralls.io/repos/twneale/treebie/badge.png?branch=master)](https://coveralls.io/r/twneale/treebie?branch=master)
-[![Latest Version](https://pypip.in/version/treebie/badge.png)](https://pypi.python.org/pypi/treebie/)
-[![Download Format](https://pypip.in/format/treebie/badge.png)](https://pypi.python.org/pypi/treebie/)
+[![Latest Version](https://img.shields.io/pypi/v/treebie.svg)](https://pypi.python.org/pypi/treebie/)
+[![Download Format](https://img.shields.io/pypi/format/treebie.svg)](https://pypi.python.org/pypi/treebie/)
 
 Provides a basic tree node implementation.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20treebie))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `treebie`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.